### PR TITLE
Update grpcio and grpcio-tools to 1.38.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-grpcio==1.18.0
-grpcio-tools==1.18.0
+grpcio==1.38.1
+grpcio-tools==1.38.1
 colorama==0.3.3
 termcolor==1.1.0
 tqdm==4.31.1

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setup(
         "Programming Language :: Python :: 3.6",
     ],
     install_requires=[
-        'grpcio==1.18.0',
-        'grpcio-tools==1.18.0',
+        'grpcio==1.38.0',
+        'grpcio-tools==1.38.0',
         'colorama==0.3.3',
         'termcolor==1.1.0',
         'tqdm==4.31.1'


### PR DESCRIPTION
Update `grpcio` and `grpcio-tools` to their latest versions.

Followed guidance here https://github.com/netsaj/python-protobuf-compiler/issues/2

I was getting compilation errors trying to install another project and found that the older version of grpc uses an older version of glibc and was causing some compiler errors.